### PR TITLE
Fix typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
-# Contributing to Github Extensions
+# Contributing to GitHub Extensions
 
-Thank you for considering contributing to Github Extensions! We welcome all contributions from the community, whether they are code contributions, bug reports, feature requests, or anything else.
+Thank you for considering contributing to GitHub Extensions! We welcome all contributions from the community, whether they are code contributions, bug reports, feature requests, or anything else.
 
 
 ## How to contribute
 
-Here are the steps to follow to contribute to Github Extensions:
+Here are the steps to follow to contribute to GitHub Extensions:
 
 1. Fork the repository and clone it to your local machine.
 2. Create a new branch for your changes: `git checkout -b my-branch`
@@ -18,7 +18,7 @@ Here are the steps to follow to contribute to Github Extensions:
 
 ## Code guidelines
 
-Please follow these guidelines when writing code for Github Extensions:
+Please follow these guidelines when writing code for GitHub Extensions:
 
 1. Be consistent with the existing code.
 2. Write clear code & self-explaining code.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Github Extensions
+# GitHub Extensions
 
 ## Getting Started
 

--- a/public/chrome.manifest.json
+++ b/public/chrome.manifest.json
@@ -3,7 +3,7 @@
   "name": "GitHub Extensions",
   "version": "0.1.0",
   "version_name": "v0.1.0-beta",
-  "description": "GitHub Extensions is an extensions for managing Github repositories",
+  "description": "GitHub Extensions is an extensions for managing GitHub repositories",
   "icons": { },
   "action": {
     "default_icon": { },

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Github Extensions</title>
+    <title>GitHub Extensions</title>
 </head>
 <body>
     <script src="dist/bundle.js">


### PR DESCRIPTION
Rename `Github` to `GitHub`